### PR TITLE
MO-514

### DIFF
--- a/src/ios/HappieCameraViewController.swift
+++ b/src/ios/HappieCameraViewController.swift
@@ -192,14 +192,22 @@ import CoreMotion
     
     //MARK: AVFoundation Implementation
     func beginSession(){
+        let currentDevice: UIDevice = UIDevice.currentDevice()
+        var orientation: UIDeviceOrientation = currentDevice.orientation;
+        var width = UIScreen.mainScreen().bounds.size.width;
+        var height = UIScreen.mainScreen().bounds.size.height;
+        if(orientation == UIDeviceOrientation.LandscapeLeft ||
+            orientation == UIDeviceOrientation.LandscapeRight){
+            orientation = UIDeviceOrientation.Portrait;
+            let dummyVar = width;
+            width=height;
+            height=dummyVar;
+        }
         let previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
 
-        previewLayer.frame = CGRectMake(0, 0, UIScreen.mainScreen().bounds.size.width, UIScreen.mainScreen().bounds.size.height)
-        previewLayer.bounds = CGRectMake(0, 0, UIScreen.mainScreen().bounds.size.width, UIScreen.mainScreen().bounds.size.height)
-        previewLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
-        
-        let currentDevice: UIDevice = UIDevice.currentDevice()
-        let orientation: UIDeviceOrientation = currentDevice.orientation
+        previewLayer.frame = CGRectMake(0, 0, width,height)
+        previewLayer.bounds = CGRectMake(0, 0,width,height)
+        previewLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;        
         
         previewLayer.connection.videoOrientation = AVCaptureVideoOrientation(rawValue: orientation.rawValue)!;
         camPreview.layer.addSublayer(previewLayer)

--- a/src/ios/HappieCameraViewController.swift
+++ b/src/ios/HappieCameraViewController.swift
@@ -23,7 +23,8 @@ import CoreMotion
     var flashState = 2; //0 = off, 1 = On, 2 = Auto
     var quadState = 0; //0 = UL , 1 = UR, 2 = LL, 3 = LR
     var badgeCounter = 0;
-
+    var oldOrientationValue: UIDeviceOrientation = UIDeviceOrientation.Portrait;
+    
      //send data back to the plugin class
     var jsonGen = HappieCameraJSON();
     var thumbGen = HappieCameraThumb();
@@ -194,6 +195,7 @@ import CoreMotion
     func beginSession(){
         let currentDevice: UIDevice = UIDevice.currentDevice()
         var orientation: UIDeviceOrientation = currentDevice.orientation;
+        oldOrientationValue = orientation;
         var width = UIScreen.mainScreen().bounds.size.width;
         var height = UIScreen.mainScreen().bounds.size.height;
         if(orientation == UIDeviceOrientation.LandscapeLeft ||
@@ -241,7 +243,7 @@ import CoreMotion
 //        if(backCameraDevice?.flashAvailable){
 //            setFlashModeToAuto(backCameraDevice!)
 //        }
-
+        UIDevice.currentDevice().setValue(oldOrientationValue.rawValue, forKey: "orientation")
         delegate!.cameraFinished(self, JSON: pathJSON)
     }
 
@@ -251,7 +253,7 @@ import CoreMotion
 //        if(backCameraDevice?.flashAvailable){
 //            setFlashModeToAuto(backCameraDevice!)
 //        }
-
+        UIDevice.currentDevice().setValue(oldOrientationValue.rawValue, forKey: "orientation")
         delegate!.cameraFinished(self, JSON: pathJSON)
     }
 


### PR DESCRIPTION
APP FIX: iOS camera issues
When camera is opened in landscape mode in iPhone then camera screen is
not displaying correctly (there is only half part of preview).
It’s fixed
