### PR TITLE
Fix resizing to max image size

### DIFF
--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -238,7 +238,9 @@ public class HappieCameraActivity extends Activity {
             }
             Camera.Size currentSize = params.getPictureSize();
             Camera.Size maxSize = validPhotoDimensions.get(i);
-            if (currentSize.height < maxSize.height || currentSize.width < maxSize.width) {
+            if (currentSize.height > maxSize.height || currentSize.width > maxSize.width) {
+                Log.d(TAG, "current size greater than max size, resize to max size " + maxSize.width + "x" + maxSize.height);
+
                 params.setPictureSize(maxSize.width, maxSize.height);
             }
 
@@ -251,8 +253,9 @@ public class HappieCameraActivity extends Activity {
             if (params.getSupportedPictureSizes() != null) {
                 Camera.Size currentSize = params.getPictureSize();
                 Camera.Size maxSize = params.getSupportedPictureSizes().get(0);
-                if (currentSize.height < maxSize.height ||
-                        currentSize.width < maxSize.width) {
+                if (currentSize.height > maxSize.height || currentSize.width > maxSize.width) {
+                    Log.d(TAG, "exception: current size greater than max size, resize to max size " + maxSize.width + "x" + maxSize.height);
+
                     params.setPictureSize(maxSize.width, maxSize.height);
                 }
             }


### PR DESCRIPTION
This is an Android fix that fixes resizing to the max image size such as when the `quality` is set to `0`.  I found having the debug logs were helpful in troubleshooting but can remove them if  preferable.

Let me know if you have any other suggestions or prefer any modifications as I didn't see any contributors guide.  Thanks.